### PR TITLE
Store route on trie node

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,26 +21,21 @@ function Wayfarer (dft) {
 
   // define a route
   // (str, fn) -> obj
-  function on (route, fn) {
+  function on (route, cb) {
     assert.equal(typeof route, 'string')
-    assert.equal(typeof fn, 'function')
+    assert.equal(typeof cb, 'function')
 
-    var cb = fn._wayfarer && fn._trie ? fn : proxy
     route = route || '/'
-    cb.route = route
 
     if (cb._wayfarer && cb._trie) {
       _trie.mount(route, cb._trie.trie)
     } else {
       var node = _trie.create(route)
       node.cb = cb
+      node.route = route
     }
 
     return emit
-
-    function proxy () {
-      return fn.apply(this, Array.prototype.slice.call(arguments))
-    }
   }
 
   // match and call a route
@@ -71,7 +66,7 @@ function Wayfarer (dft) {
 
   function Route (matched) {
     this.cb = matched.cb
-    this.route = matched.cb.route
+    this.route = matched.route
     this.params = matched.params
   }
 }

--- a/test/router.js
+++ b/test/router.js
@@ -336,23 +336,33 @@ tape('router', function (t) {
   t.test('should expose .route property', function (t) {
     t.plan(1)
     var r = wayfarer()
-    r.on('/foo', function () {
-      t.equal(this.route, '/foo', 'exposes route property')
+    r.on('/foo', function () {})
+    t.equal(r.match('/foo').route, '/foo', 'exposes route property')
+  })
+
+  t.test('should be called with self', function (t) {
+    t.plan(1)
+    var r = wayfarer()
+    r.on('/foo', function callback () {
+      t.equal(this, callback, 'calling context is self')
     })
     r('/foo')
   })
 
-  t.test('should not mutate callback parameter', function (t) {
-    t.plan(4)
+  t.test('can register callback on many routes', function (t) {
+    t.plan(6)
     var r = wayfarer()
     var routes = ['/foo', '/bar']
     r.on('/foo', callback)
     r.on('/bar', callback)
-    r('/foo')
-    r('/bar')
+    for (var i = 0, len = routes.length, matched; i < len; i++) {
+      matched = r.match(routes[i])
+      t.equal(matched.cb, callback, 'matched callback is same')
+      t.equal(matched.route, routes[i], 'matched route is same')
+      r(routes[i])
+    }
     function callback () {
-      t.notEqual(this, callback, 'callback was proxied')
-      t.equal(this.route, routes.shift(), 'proxy exposes route property')
+      t.equal(this, callback, 'calling context is same')
     }
   })
 })

--- a/trie.js
+++ b/trie.js
@@ -13,7 +13,7 @@ function Trie () {
 
 // create a node on the trie at route
 // and return a node
-// str -> null
+// str -> obj
 Trie.prototype.create = function (route) {
   assert.equal(typeof route, 'string', 'route should be a string')
   // strip leading '/' and split routes


### PR DESCRIPTION
This reverts #66 in favor of storing the route on the trie node. Using a proxy callback worked for mitigating the immediate problem with reusing route callbacks but it also makes it difficult to register anything other than functions as route callbacks.

I.e. if I was to register a class as a route callback I'd probably want that class returned from `.match` and not a wrapper function. This is relevant if you'd want to register top level components as routes in choo.

This does however break the _undocumented_ functionality of accessing the route on `this` in the callback. I dunno what that means for semver 🤔