### PR TITLE
Use Object.assign instead of xtend

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 node_js:
-- "0.10"
-- "1"
-- "2"
+- "4"
+- "6"
+- "8"
+- "10"
+- "12"
 sudo: false
 language: node_js
 script: "npm run test-cov"

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "browser"
   ],
   "license": "MIT",
-  "dependencies": {
-    "xtend": "^4.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "istanbul": "^0.4.5",
     "mocha": "^3.1.2",

--- a/trie.js
+++ b/trie.js
@@ -1,6 +1,4 @@
-var mutate = require('xtend/mutable')
 var assert = require('assert')
-var xtend = require('xtend')
 
 module.exports = Trie
 
@@ -96,7 +94,7 @@ Trie.prototype.match = function (route) {
   var node = search(0, this.trie)
 
   if (!node) return undefined
-  node = xtend(node)
+  node = Object.assign({}, node)
   node.params = params
   return node
 }
@@ -120,7 +118,7 @@ Trie.prototype.mount = function (route, trie) {
     node = this.create(head)
   }
 
-  mutate(node.nodes, trie.nodes)
+  Object.assign(node.nodes, trie.nodes)
   if (trie.name) node.name = trie.name
 
   // delegate properties from '/' to the new node
@@ -130,7 +128,7 @@ Trie.prototype.mount = function (route, trie) {
       if (key === 'nodes') return
       node[key] = node.nodes[''][key]
     })
-    mutate(node.nodes, node.nodes[''].nodes)
+    Object.assign(node.nodes, node.nodes[''].nodes)
     delete node.nodes[''].nodes
   }
 }


### PR DESCRIPTION
Since we are removing xtend from Choo in https://github.com/choojs/choo/pull/616, we should also get rid of it in dependencies, else it'd be included anyway!